### PR TITLE
feat: add option to toggle Typst Tools panel on startup

### DIFF
--- a/src/core/settings/settings.ts
+++ b/src/core/settings/settings.ts
@@ -22,6 +22,7 @@ export interface Settings {
   enableInlinePreview: boolean;
   disablePackageCache: boolean;
   enableShortcutKeys: boolean;
+  openTypstToolsOnStartup: boolean;
   preamble: string;
   processor: {
     inline?: {
@@ -51,6 +52,7 @@ export const DEFAULT_SETTINGS: Settings = {
   enableInlinePreview: true,
   disablePackageCache: false,
   enableShortcutKeys: true,
+  openTypstToolsOnStartup: true,
   preamble: [
     '#set page(margin: 0pt, width: auto, height: auto)',
     '#show raw: set text(size: 1.25em)',
@@ -254,6 +256,17 @@ export class SettingTab extends PluginSettingTab {
           this.plugin.settings.autoBaseColor = value;
           if (value) this.plugin.applyBaseColor();
 
+          this.plugin.saveSettings();
+        });
+      });
+
+    new Setting(containerEl)
+      .setName('Open Typst Tools on startup')
+      .setDesc("Open Typst tools in side panel when launching Obsidian.")
+      .addToggle((toggle) => {
+        toggle.setValue(this.plugin.settings.openTypstToolsOnStartup);
+        toggle.onChange((value) => {
+          this.plugin.settings.openTypstToolsOnStartup = value;
           this.plugin.saveSettings();
         });
       });

--- a/src/main.ts
+++ b/src/main.ts
@@ -118,7 +118,9 @@ export default class ObsidianTypstMate extends Plugin {
       this.registerView(TypstTextView.viewtype, (leaf) => new TypstTextView(leaf));
       this.registerView(TypstPDFView.viewtype, (leaf) => new TypstPDFView(leaf, this));
       this.registerExtensions(['typ'], TypstPDFView.viewtype);
-      this.activateLeaf();
+      if (this.settings.openTypstToolsOnStartup) {
+        this.activateLeaf();
+      }
 
       // コマンドを登録する
       this.addCommands();


### PR DESCRIPTION
This PR simply adds an option to toggle the default behavior of opening Typst Tools in side panel. Personally speaking, it is a little annoying.

One problem is that when relaunching Obsidian with this new option disabled, existing Typst Tools panel will be recognized as inactive and closed right after startup. But the panel can be opened normally via command afterwards.

I am not very familiar with Typescript, any suggestions are appreciated.