### PR TITLE
feat: download wasm in chunks to prevent memory explosion

### DIFF
--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -8,5 +8,6 @@ declare global {
   interface GitHubAsset {
     name: string;
     url: string;
+    size: number;
   }
 }


### PR DESCRIPTION
This PR fixes an `OutOfMemoryError` that causes the plugin to crash when downloading the wasm when memory is limited, like the android mobile app. Fixes #15.

I was trying to debug why it crashes on startup, and found that if I download and put the wasm in the plugin folder myself the plugin works fine on mobile, so the plugin is crashing when it tries to download the WASM. This is the logcat error:

```
608us total 12.337ms
01-10 16:07:10.360 23039 23737 W md.obsidian: Throwing OutOfMemoryError "Failed to allocate a 93803596 byte allocation with 100597760 free bytes and 109MB until OOM, target footprint 254043760, growth limit 268435456" (VmSize 34783092 kB)
01-10 16:07:10.495 23039 23737 I md.obsidian: Starting a blocking GC Alloc
01-10 16:07:11.887 23039 23737 I md.obsidian: Alloc young concurrent mark compact GC freed 124KB AllocSpace bytes, 0(0B) LOS objects, 2% free, 235MB/242MB, paused 78us,1.017ms total 1.391s
01-10 16:07:11.887 23039 23047 I md.obsidian: WaitForGcToComplete blocked HeapTrim on Alloc for 438.854ms
01-10 16:07:11.887 23039 23737 I md.obsidian: Forcing collection of SoftReferences for 44MB allocation
01-10 16:07:13.326 23039 23737 I md.obsidian: Clamp target GC heap from 332MB to 256MB
01-10 16:07:13.326 23039 23737 I md.obsidian: Alloc concurrent mark compact GC freed 72KB AllocSpace bytes, 0(0B) LOS objects, 7% free, 236MB/256MB, paused 110us,985us total 1.439s
01-10 16:07:13.327 23039 23737 W md.obsidian: Throwing OutOfMemoryError "Failed to allocate a 46901808 byte allocation with 19958160 free bytes and 19MB until OOM, target footprint 268435456, growth limit 268435456" (VmSize 34829940 kB)
01-10 16:07:13.327 23039 23737 I md.obsidian: Starting a blocking GC Alloc
01-10 16:07:13.706 23039 23737 I md.obsidian: Alloc young concurrent mark compact GC freed 296KB AllocSpace bytes, 18(1064KB) LOS objects, 7% free, 235MB/256MB, paused 89us,496us total 379.586ms
01-10 16:07:13.707 23039 23737 I md.obsidian: Forcing collection of SoftReferences for 44MB allocation
01-10 16:07:15.017 23039 23737 I md.obsidian: Clamp target GC heap from 331MB to 256MB
01-10 16:07:15.017 23039 23737 I md.obsidian: Alloc concurrent mark compact GC freed 36KB AllocSpace bytes, 0(0B) LOS objects, 7% free, 235MB/256MB, paused 85us,1.018ms total 1.309s
01-10 16:07:15.017 23039 23737 W md.obsidian: Throwing OutOfMemoryError "Failed to allocate a 46901808 byte allocation with 21256592 free bytes and 20MB until OOM, target footprint 268435456, growth limit 268435456" (VmSize 34820916 kB)
--------- beginning of crash
01-10 16:07:15.018 23039 23737 E AndroidRuntime: FATAL EXCEPTION: pool-11-thread-1
01-10 16:07:15.018 23039 23737 E AndroidRuntime: Process: md.obsidian, PID: 23039
01-10 16:07:15.018 23039 23737 E AndroidRuntime: java.lang.OutOfMemoryError: Failed to allocate a 46901808 byte allocation with 21256592 free bytes and 20MB until OOM, target footprint 268435456, growth limit 268435456
01-10 16:07:15.018 23039 23737 E AndroidRuntime:        at java.lang.StringFactory.newStringFromChars(StringFactory.java:124)
01-10 16:07:15.018 23039 23737 E AndroidRuntime:        at java.lang.StringFactory.newStringFromBytes(StringFactory.java:109)
01-10 16:07:15.018 23039 23737 E AndroidRuntime:        at java.lang.StringFactory.newStringFromBytes(StringFactory.java:79)
01-10 16:07:15.018 23039 23737 E AndroidRuntime:        at android.util.Base64.encodeToString(Base64.java:459)
01-10 16:07:15.018 23039 23737 E AndroidRuntime:        at com.capacitorjs.plugins.app.AppPlugin.requestUrlAndroid(SourceFile:254)
01-10 16:07:15.018 23039 23737 E AndroidRuntime:        at com.capacitorjs.plugins.app.AppPlugin.lambda

requestUrlrequestUrl

3(SourceFile:38)
01-10 16:07:15.018 23039 23737 E AndroidRuntime:        at com.capacitorjs.plugins.app.AppPlugin.r(SourceFile:1)
01-10 16:07:15.018 23039 23737 E AndroidRuntime:        at com.capacitorjs.plugins.app.d.run(SourceFile:1)
01-10 16:07:15.018 23039 23737 E AndroidRuntime:        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1154)
01-10 16:07:15.018 23039 23737 E AndroidRuntime:        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:652)
01-10 16:07:15.018 23039 23737 E AndroidRuntime:        at java.lang.Thread.run(Thread.java:1563)
```

When `requestUrl` downloads the ~30MB WASM file natively, it converts that data into a String to pass it to the JavaScript WebView. So the wasm is converted into a base64 using UTF-16, which temporarily uses alot (more than 93mB) of memory very quickly, causing the crash.

Since we cannot use javascript's `fetch()` due to github release CORS restrictions, the wasm is now downloaded in 5mB chunks using `Range` headers, which fits inside the android heap, and is reassembled inside Javascript.

I tested this on my Android OnePlus 12 (which previously crashed 100% of the time on startup). The plugin now downloads the WASM successfully, initializes, and renders notes without issues.