### PR TITLE
Fixed tags being duplicated when importing.

### DIFF
--- a/src/libs/typst.ts
+++ b/src/libs/typst.ts
@@ -382,7 +382,7 @@ export default class TypstManager {
 
   syncFileCache(cache: CachedMetadata): boolean {
     const defs = (cache.frontmatter?.definitions ?? []) as string[];
-    const tags = expandHierarchicalTags(getAllTags(cache) ?? []).filter((tag) => this.tagFiles.has(tag));
+    const tags = expandHierarchicalTags(getAllTags(cache) ?? []).values().toArray().filter((tag) => this.tagFiles.has(tag));
 
     const currentHash = JSON.stringify([tags, defs]);
     if (currentHash === this.lastStateHash) return false;

--- a/src/utils/tags.ts
+++ b/src/utils/tags.ts
@@ -1,14 +1,14 @@
-export function expandHierarchicalTags(tags: string[]): string[] {
-  const expanded: string[] = [];
+export function expandHierarchicalTags(tags: string[]): Set<string> {
+  const expanded: Set<string> = new Set();
 
   for (const tag of tags) {
     const parts = tag.slice(1).split('/');
     let current = parts[0]!;
-    expanded.push(current);
+    expanded.add(current);
 
     for (let i = 1; i < parts.length; i++) {
       current = `${current}/${parts[i]}`;
-      expanded.push(current);
+      expanded.add(current);
     }
   }
 


### PR DESCRIPTION
[This change](https://github.com/azyarashi/obsidian-typst-mate/commit/ce3c8dd7d56d044eb489d3b3830856258e884ece#diff-a3f152c368dac83a5a1961f864c5ac8bcf65bd3e84e1962314fc38bbb32c5a9dR2) changes the `expandHierarchicalTags` from a `Set` to a `string[]` this means that tags that share a parent will leave the parent duplicated, for instance, `#math/algebra` and `#math/geometry` on the same file will cause two instances of `#math`, this could affect the order in which files are imported.

I confirmed this is the case with some simple `console.log` statements, it is indeed duplicated even in the final `this.preamble`, I thought about just opening an issue but it's a simple fix so I might as well just fix it, sorry for the incovenience.