### PR TITLE
Minor tag import fix and non-tag imports

### DIFF
--- a/src/libs/typst.ts
+++ b/src/libs/typst.ts
@@ -366,7 +366,7 @@ export default class TypstManager {
     this.lastStateHash = currentHash;
 
     this.preamble = '';
-    for (const tag of tags) this.preamble += `#import "tags/${tag.replace('/', '.')}.typ": *;`;
+    for (const tag of tags) this.preamble += `#import "tags/${tag.replaceAll('/', '.')}.typ": *;`;
     // Frontmatter variable definitions
     for (const def of defs) this.preamble += `#let ${def};`;
 


### PR DESCRIPTION
Hey it's me again, the main thing in this pull request is the fix in `collectTagFiles`, where before when tags were added to the `tagFiles` we had a `.replace(".", "/")`, however, apparently in TypeScript `.replace` only replaces the _first_ ocurrence, and so therefore it would not work for longer tags, `foo.bar.baz.typ` would turn into `foo/bar.baz` which then obviously would not work, this fixes that by changing `replace` with `replaceAll`.

The second thing is I made the plugin scan for `.typ` files in the top of the `importPath`, such that if you have a file like `.typst/common.typ` it will be added to the `WasmWorld` and you will then be able to use it manually via `#import`, however it is not automatically added anywhere.
I added this because I noticed that I had some content that I would repeat in multiple different tags, for instance `#math` and `#physics` share quite a lot of content, and it is therefore useful to have common file from both and just import from that.

I'm down to remove this last feature if you don't like it, but the fix should definitely be added.