### PR TITLE
chore: improve texts in the UI

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -296,11 +296,11 @@ export default class ObsidianTypstMate extends Plugin {
 
     this.addCommand({
       id: 'tex2typ',
-      name: 'Replace tex in markdown content or selection to typst',
+      name: 'Replace TeX with Typst in markdown content or selection',
       editorCallback: async (editor) => {
         const view = editor.cm;
         if (!view) {
-          new Notice('Active view is not found.');
+          new Notice('No active view found.');
           return;
         }
 

--- a/src/ui/modals/processorExt.ts
+++ b/src/ui/modals/processorExt.ts
@@ -15,7 +15,7 @@ export class ProcessorExtModal extends Modal {
     new Setting(this.contentEl).setName(processor.id).setHeading();
 
     // Preamble
-    new Setting(this.contentEl).setName(`Use preamble`).addToggle((toggle) => {
+    new Setting(this.contentEl).setName('Use preamble').addToggle((toggle) => {
       toggle.setValue(!processor.noPreamble);
 
       toggle.onChange(() => {
@@ -24,7 +24,7 @@ export class ProcessorExtModal extends Modal {
       });
     });
 
-    new Setting(this.contentEl).setName(`Disable symbol suggest`).addToggle((toggle) => {
+    new Setting(this.contentEl).setName('Disable symbol suggest').addToggle((toggle) => {
       toggle.setValue(processor.disableSuggest ?? false);
 
       toggle.onChange(() => {

--- a/src/ui/modals/templateSelect.ts
+++ b/src/ui/modals/templateSelect.ts
@@ -19,14 +19,14 @@ export class TemplateSelectModal extends Modal {
 
     const importPath = this.plugin.settings.importPath;
     if (!(await this.plugin.app.vault.adapter.exists(importPath))) {
-      new Notice('Typst directory does not exist. Please see advanced settings.');
+      new Notice('Typst directory does not exist. Check the Advanced settings.');
       this.close();
       return;
     }
 
     const templatePath = `${importPath}/templates`;
     if (!(await this.plugin.app.vault.adapter.exists(templatePath))) {
-      new Notice('Template directory does not exist. Please create `templates` directory in import path.');
+      new Notice('Template directory does not exist. Please create a `templates` directory in the import path.');
       this.close();
       return;
     }

--- a/src/ui/settingsTab/components/font.ts
+++ b/src/ui/settingsTab/components/font.ts
@@ -19,7 +19,7 @@ export class FontList {
     if (Platform.isDesktopApp) {
       new Setting(containerEl)
         .setName('Import Font')
-        .setDesc('Desktop App only. Typst supports ttf/otf/ttc/otc.')
+        .setDesc('Desktop App only. Typst supports .ttf, .otf, .ttc, and .otc fonts.')
         .addSearch((search) => {
           search.setPlaceholder('Filter Font Name');
 
@@ -35,7 +35,7 @@ export class FontList {
         });
 
       this.fontDataCountEl = containerEl.createDiv();
-      this.fontDataCountEl.textContent = 'Click to get system font list';
+      this.fontDataCountEl.textContent = 'Click to load the system font list';
 
       this.fontDataTableEl = containerEl.createDiv('typstmate-settings-table typstmate-hidden');
     }
@@ -43,7 +43,7 @@ export class FontList {
     // 読み込み済みフォント
     const settings = new Setting(containerEl)
       .setName('Imported Fonts')
-      .setDesc('The string next to the font name is used to identify fonts that share the same PostScript name.');
+      .setDesc('The string next to each font name is used to identify fonts that share the same PostScript name.');
     if (Platform.isDesktopApp) {
       settings.addButton((button) => {
         button.setTooltip('Open Folder');

--- a/src/ui/settingsTab/components/processor.ts
+++ b/src/ui/settingsTab/components/processor.ts
@@ -13,7 +13,7 @@ import { ProcessorExtModal } from '@/ui/modals/processorExt';
 
 const description = {
   inline:
-    'It expects only inline elements to be placed and no extra line breaks (including ; in Code mode) on the last line. If you use block elements, please convert them to inline elements using the box function. If you want to use the same typesetting as Typst, set the style to inline. If you want to use display math equations, setting $#math.equation($ {CODE} $, block: false)$ is recommended.',
+    'Use only inline elements, with no extra line breaks (including ; in Code mode) on the last line. If you use block elements, convert them to inline elements using the box function. To use the same typesetting as Typst, set the style to inline. For display math equations, using $#math.equation($ {CODE} $, block: false)$ is recommended.',
   display: '',
   codeblock: '',
   excalidraw: '',
@@ -256,7 +256,7 @@ export class ProcessorList {
             }
 
             const isDuplicate = processors.some((p, i) => i !== currentIndex && p.id === cleanId && cleanId !== '');
-            if (isDuplicate) return new Notice('ID is duplicate');
+            if (isDuplicate) return new Notice('This ID already exists.');
 
             this.plugin.settings.processor[this.kind].processors[Number(processorEl.id)]!.id = cleanId;
             this.updateDraggability();

--- a/src/ui/settingsTab/tabs/advanced.ts
+++ b/src/ui/settingsTab/tabs/advanced.ts
@@ -8,7 +8,7 @@ export function addAdvancedTab(plugin: ObsidianTypstMate, containerEl: HTMLEleme
   const setting = new Setting(containerEl)
     .setName('Typst file import path')
     .setDesc(
-      'The directory in your vault in which to look for typst files to be allowed to import, if the path does not exist or is empty the feature is disabled',
+      'The directory in your vault to look for Typst files to import. If the path does not exist or is empty, this feature is disabled.',
     )
     .addText((text) => {
       text.setValue(String(plugin.settings.importPath ?? DEFAULT_SETTINGS.importPath));
@@ -49,7 +49,7 @@ export function addAdvancedTab(plugin: ObsidianTypstMate, containerEl: HTMLEleme
 
   new Setting(containerEl)
     .setName('Open Typst Tools on Startup')
-    .setDesc('Open Typst tools in side panel when launching Obsidian.')
+    .setDesc('Open Typst Tools in the side panel when launching Obsidian.')
     .addToggle((toggle) => {
       toggle.setValue(plugin.settings.openTypstToolsOnStartup);
       toggle.onChange((value) => {

--- a/src/ui/settingsTab/tabs/compiler.ts
+++ b/src/ui/settingsTab/tabs/compiler.ts
@@ -19,8 +19,8 @@ export function addCompilerTab(
 
 function addCompilerSettings(plugin: ObsidianTypstMate, containerEl: HTMLElement) {
   new Setting(containerEl)
-    .setName('Skip Preparation Waiting')
-    .setDesc('Defers initialization at startup (Unstable on mobile). Reduces startup time but delays first render.')
+    .setName('Skip Startup Preparation')
+    .setDesc('Defer initialization at startup (unstable on mobile). Reduces startup time but delays the first render.')
     .addToggle((toggle) => {
       toggle.setValue(plugin.settings.skipPreparationWaiting);
       toggle.onChange((value) => {
@@ -32,7 +32,7 @@ function addCompilerSettings(plugin: ObsidianTypstMate, containerEl: HTMLElement
   new Setting(containerEl)
     .setName('Disable Package Cache')
     .setDesc(
-      'Disable caching of imported packages. Useful for low memory environments but requires re-downloading packages.',
+      'Disable caching of imported packages. Useful for low-memory environments, but requires re-downloading packages.',
     )
     .addToggle((toggle) => {
       toggle.setValue(plugin.settings.disablePackageCache);
@@ -70,7 +70,7 @@ function addSubTabs(
       new Setting(containerEl)
         .setName('Package')
         .setDesc(
-          'When a package is imported, the cache is used instead of the actual files for faster performance. If you make changes directly, please click the package icon to refresh the cache (plugin reload is required.)',
+          'When a package is imported, the cache is used instead of the actual files for faster performance. If you make changes directly, click the package icon to refresh the cache (plugin reload is required).',
         )
         .setHeading();
       new PackagesList(plugin, containerEl);

--- a/src/ui/settingsTab/tabs/editor.ts
+++ b/src/ui/settingsTab/tabs/editor.ts
@@ -44,7 +44,7 @@ function addMathDecorationSettings(plugin: ObsidianTypstMate, containerEl: HTMLE
 
   new Setting(containerEl)
     .setName('Conceal Math Symbols')
-    .setDesc('Conceal math symbols (e.g. integral to ∫) in the editor.')
+    .setDesc('Conceal math symbols (e.g., integral to ∫) in the editor.')
     .addToggle((toggle) => {
       toggle.setValue(plugin.settings.concealMathSymbols ?? DEFAULT_SETTINGS.concealMathSymbols);
 
@@ -60,7 +60,7 @@ function addMathDecorationSettings(plugin: ObsidianTypstMate, containerEl: HTMLE
   let revealDelayToggle: ToggleComponent | null = null;
   new Setting(containerEl)
     .setName('Enable Math Symbol Reveal Delay')
-    .setDesc('Enable delay before revealing concealed math symbols when cursor is nearby.')
+    .setDesc('Add a delay before revealing concealed math symbols when the cursor is nearby.')
     .addToggle((toggle) => {
       revealDelayToggle = toggle;
       toggle.setValue(
@@ -78,7 +78,7 @@ function addMathDecorationSettings(plugin: ObsidianTypstMate, containerEl: HTMLE
   let revealDelayText: TextComponent | null = null;
   new Setting(containerEl)
     .setName('Conceal Math Symbol Reveal Delay Duration (ms)')
-    .setDesc('Milliseconds to wait before revealing the symbol text.')
+    .setDesc('Time in milliseconds to wait before revealing symbol text.')
     .addText((text) => {
       revealDelayText = text;
       text.setValue(String(plugin.settings.mathSymbolRevealDelay ?? DEFAULT_SETTINGS.mathSymbolRevealDelay));
@@ -97,7 +97,7 @@ function addMathDecorationSettings(plugin: ObsidianTypstMate, containerEl: HTMLE
 
   new Setting(containerEl)
     .setName('Complement Symbol with Unicode')
-    .setDesc('Automatically replaces typed symbols with Unicode equivalents.')
+    .setDesc('Automatically replace typed symbols with their Unicode equivalents.')
     .addToggle((toggle) => {
       toggle.setValue(plugin.settings.complementSymbolWithUnicode ?? DEFAULT_SETTINGS.complementSymbolWithUnicode);
 
@@ -123,7 +123,7 @@ function addMathDecorationSettings(plugin: ObsidianTypstMate, containerEl: HTMLE
 
   new Setting(containerEl)
     .setName('Use Obsidian Theme')
-    .setDesc('Use Obsidian theme instead of Typst theme. Reload required.')
+    .setDesc('Use the Obsidian theme instead of the Typst theme. Requires reload.')
     .addToggle((toggle) => {
       toggle.setValue(plugin.settings.useObsidianTheme ?? DEFAULT_SETTINGS.useObsidianTheme!);
       toggle.onChange((value) => {
@@ -153,7 +153,7 @@ function addActionSettings(plugin: ObsidianTypstMate, containerEl: HTMLElement) 
 
   new Setting(containerEl)
     .setName('Revert Tab to Default')
-    .setDesc('Reverts the Tab key behavior to the default indentation instead of jumping to the next placeholder.')
+    .setDesc('Revert the Tab key to default indentation behavior instead of jumping to the next placeholder.')
     .addToggle((toggle) => {
       toggle.setValue(plugin.settings.revertTabToDefault ?? DEFAULT_SETTINGS.revertTabToDefault!);
       toggle.onChange((value) => {
@@ -175,7 +175,7 @@ function addActionSettings(plugin: ObsidianTypstMate, containerEl: HTMLElement) 
 
   new Setting(containerEl)
     .setName('Move to End of Math Block Before Exiting')
-    .setDesc('When exiting math, first move the cursor to the end of the block.')
+    .setDesc('When exiting math mode, move the cursor to the end of the block first.')
     .addToggle((toggle) => {
       toggle.setValue(
         plugin.settings.moveToEndOfMathBlockBeforeExiting ?? DEFAULT_SETTINGS.moveToEndOfMathBlockBeforeExiting!,
@@ -204,7 +204,7 @@ function addActionSettings(plugin: ObsidianTypstMate, containerEl: HTMLElement) 
 
   new Setting(containerEl)
     .setName('Disable Macro')
-    .setDesc('Disable default macros like mk and dm.')
+    .setDesc('Disable default macros such as mk and dm.')
     .addToggle((toggle) => {
       toggle.setValue(plugin.settings.disableMacro ?? DEFAULT_SETTINGS.disableMacro!);
       toggle.onChange((value) => {

--- a/src/ui/settingsTab/tabs/processor.ts
+++ b/src/ui/settingsTab/tabs/processor.ts
@@ -17,13 +17,13 @@ export function addProcessorTab(
     .setDesc(
       new CustomFragment()
         .appendText(
-          'In each mode, the first matching Processor ID from the top will be used. An empty Processor ID means the default and should be placed at the bottom. In the format, ',
+          'In each mode, the first matching Processor ID from the top is used. An empty Processor ID acts as the default and should be placed at the bottom. In the format, ',
         )
         .appendCodeText('{CODE}')
         .appendText(' can be used (only the first occurrence is replaced), and ')
         .appendCodeText('fontsize')
         .appendText(
-          ' can be used as an internal length value. In inline mode, separate the id and the code with a colon ',
+          ' can be used as an internal length value. In inline mode, separate the ID and the code with a colon ',
         )
         .appendCodeText(':')
         .appendText(

--- a/src/ui/settingsTab/tabs/renderer.ts
+++ b/src/ui/settingsTab/tabs/renderer.ts
@@ -27,7 +27,7 @@ export function addRendererTab(plugin: ObsidianTypstMate, containerEl: HTMLEleme
   new Setting(containerEl)
     .setName('Patch PDF Export')
     .setDesc(
-      'Temporarily disable AutoBaseColor and use BaseColor during PDF Export to fix white background issues in dark themes.',
+      'Temporarily disable AutoBaseColor and use BaseColor during PDF export to fix white background issues in dark themes.',
     )
     .addToggle((toggle) => {
       toggle.setValue(plugin.settings.patchPDFExport ?? DEFAULT_SETTINGS.patchPDFExport!);
@@ -39,7 +39,7 @@ export function addRendererTab(plugin: ObsidianTypstMate, containerEl: HTMLEleme
 
   new Setting(containerEl)
     .setName('Use Theme Text Color')
-    .setDesc("Uses Obsidian's text color as the base color automatically.")
+    .setDesc("Use Obsidian's text color as the base color.")
     .addToggle((toggle) => {
       toggle.setValue(plugin.settings.autoBaseColor);
       toggle.onChange((value) => {
@@ -70,7 +70,7 @@ export function addRendererTab(plugin: ObsidianTypstMate, containerEl: HTMLEleme
   new Setting(containerEl)
     .setName('Offset')
     .setDesc(
-      'Offset for inline math. The appearance may look unappealing depending on the font used in Obsidian. Please adjust it here if necessary.',
+      'Vertical offset for inline math. The appearance may vary depending on the font used in Obsidian. Adjust as needed.',
     )
     .addSlider((slider) => {
       slider.setLimits(-0.5, 0.5, 0.05);

--- a/src/ui/views/typst-text/exportTool.ts
+++ b/src/ui/views/typst-text/exportTool.ts
@@ -188,7 +188,7 @@ export class ExportToolModal extends Modal {
 
       new Setting(contentEl)
         .setName('PPI')
-        .setDesc('Pixels per inch. Higher values mean higher resolution (e.g. 72, 144, 300).')
+        .setDesc('Pixels per inch. Higher values produce higher resolution (e.g., 72, 144, 300).')
         .addText((text) => {
           text.inputEl.type = 'number';
           text
@@ -240,7 +240,7 @@ export class ExportToolModal extends Modal {
       }
     } catch (e) {
       console.error('Export failed:', e);
-      new Notice('Export failed. Check console for details.');
+      new Notice('Export failed. Check the console for details.');
     }
   }
 }

--- a/src/ui/views/typst-tools/typstTools.ts
+++ b/src/ui/views/typst-tools/typstTools.ts
@@ -88,7 +88,7 @@ export class TypstToolsView extends ItemView {
           };
 
           const latex = contentEl.createEl('textarea');
-          latex.placeholder = 'LaTex';
+          latex.placeholder = 'LaTeX';
           latex.addClass('typstmate-form-control');
           latex.addEventListener('input', async () => {
             try {
@@ -157,7 +157,7 @@ export class TypstToolsView extends ItemView {
 
     new ButtonComponent(menuEl)
       .setIcon('refresh-ccw')
-      .setTooltip('再読み込み')
+      .setTooltip('Reload')
       .onClick(() => {
         switch (this.dropdown.getValue()) {
           case 'symbols':


### PR DESCRIPTION
UI 上に表示される英文を改善します。

#### 改善点と修正点
- 設定画面内のUIの表記として一般的な命令文で統一しました
- 冠詞の不足など明らかな文法の違いを修正しました
- 大文字小文字が不適切な箇所を修正しました Tex -> TeX など
- 細かなパンクテーションの誤りを修正しました e.g. -> e.g., など
- `再読み込み` が日本語なのを英語にしました
- そのほか、一部の表現を自然になるように変更しました

#### 文章以外の変更点
- Template Literal を使用する必要性がない個所を単純なクォートに変更しました