### PR TITLE
ci: skip ci for markdown files

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -3,7 +3,11 @@ name: Check
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - '**/*.md'
   pull_request:
+    paths-ignore:
+      - '**/*.md'
 
 jobs:
   check:


### PR DESCRIPTION
md ファイルの変更のみpushおよびPRsについてテストが実行されないようにします。