### PR TITLE
Fixed bad cache and embed rendering

### DIFF
--- a/src/libs/typst.ts
+++ b/src/libs/typst.ts
@@ -156,8 +156,9 @@ export default class TypstManager {
         const container = document.createElement('mjx-container');
         container.className = 'Mathjax';
         container.setAttribute('jax', 'CHTML');
+        const ndir = ctxToNDir(ctx.sourcePath);
 
-        mel.replaceChildren(this.render(text, container, inline ? 'inline' : 'display', ctx.sourcePath));
+        mel.replaceChildren(this.render(text, container, inline ? 'inline' : 'display', ndir, ctx.sourcePath));
 
         mel.setAttribute('contenteditable', 'false');
         mel.addClass('is-loaded');
@@ -197,7 +198,10 @@ export default class TypstManager {
           });
         this.syncFileCache(cache);
       }
-    } else this.preamble = '';
+    } else {
+      this.lastStateHash = '';
+      this.preamble = '';
+    }
 
     // プロセッサーを決定
     let processor: Processor;


### PR DESCRIPTION
This is a very minor fix, just make sure to reset the last render cache when rendering a file without a path, and fixed the function call to `render` for embed blocks.